### PR TITLE
Password and DB options, display DBSIZE in detailed stats

### DIFF
--- a/nexus_redis/conf.py
+++ b/nexus_redis/conf.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 CONNECTIONS = getattr(settings, 'NEXUS_REDIS_CONNECTIONS', [
     # {'host': '127.0.0.1', 'port': 8930},
+    # {'host': '127.0.0.1', 'port': 8932, 'password': 'secret', 'db': 2},
 ])
 
 DEFAULT_HOST = 'localhost'

--- a/nexus_redis/nexus_modules.py
+++ b/nexus_redis/nexus_modules.py
@@ -17,7 +17,12 @@ class RedisModule(nexus.NexusModule):
             if netloc in caches:
                 continue
             try:
-                caches[netloc] = Redis(host=config.get('host'), port=config.get('port'))
+                caches[netloc] = Redis(
+                    host=config.get('host'),
+                    port=config.get('port'),
+                    password=config.get('password'),
+                    db=config.get('db'),
+                    )
             except Exception, e:
                 self.logger.exception(e)
         return caches

--- a/nexus_redis/nexus_modules.py
+++ b/nexus_redis/nexus_modules.py
@@ -39,6 +39,7 @@ class RedisModule(nexus.NexusModule):
                 stats = {'online': 0}
             else:
                 stats['online'] = 1
+                stats['db_size'] = conn.dbsize()
             results[netloc] = stats
 
         socket.setdefaulttimeout(default_timeout)


### PR DESCRIPTION
A password is required in order to deploy Nexus to Heroku (using the RedisToGo addon), and being able to specify which DB to connect to is useful.

I also added DBSIZE to the detailed stats.
